### PR TITLE
Fix service call to boot with no env

### DIFF
--- a/boris-service/main/boris-service.hs
+++ b/boris-service/main/boris-service.hs
@@ -52,7 +52,7 @@ main = do
     cenv = configureRetries env
 
   Boot.Boot logx discoverx buildx <-
-    Nest.force $ Boot.boot (pure cenv) mkBalanceConfig
+    Nest.force $ Boot.boot mkBalanceConfig
 
   asyncs <- mapM async $ L.replicate n (run logx buildx discoverx cenv queue work pin)
   results <- forM asyncs $ waitCatch


### PR DESCRIPTION
@markhibberd @novemberkilo 

This was broken in 30925d070f73bef8faaf2ca79dbb371f8128e150